### PR TITLE
Updated rockylinux.org to a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rocky Linux Gatsby Project
-If you're here, you may have seen my streams around migrating the Rocky Linux website (rockylinux.org) to Gatsby. Below you'll find a checklist of tasks that have been completed and what is still left to do. Contributions are encouraged!
+If you're here, you may have seen my streams around migrating the Rocky Linux website ([rockylinux.org](https://rockylinux.org/)) to Gatsby. Below you'll find a checklist of tasks that have been completed and what is still left to do. Contributions are encouraged!
 
 ## To Do
 - [X] News Posts


### PR DESCRIPTION
I changed rockylinux.org to a clickable link. Simple suggestion for a fix, but it can help users reference the Rocky Linux website more easily directly from the readme.